### PR TITLE
Add customization for background and text

### DIFF
--- a/octoprint_tempsgraph/__init__.py
+++ b/octoprint_tempsgraph/__init__.py
@@ -22,7 +22,7 @@ class TempsgraphPlugin(octoprint.plugin.SettingsPlugin,
                 dict(
                     name="Custom",
                     value="#fffff")],
-            legendPresets=[
+            axisesPresets=[
                 dict(
                     name="Default",
                     value=None),
@@ -34,7 +34,7 @@ class TempsgraphPlugin(octoprint.plugin.SettingsPlugin,
                     value="#fffff")],
             color=dict(
                 backgroundColor = 'Default',
-                legendColor="Default"
+                axisesColor="Default"
             )
             
         )

--- a/octoprint_tempsgraph/__init__.py
+++ b/octoprint_tempsgraph/__init__.py
@@ -4,13 +4,39 @@ from __future__ import absolute_import
 import octoprint.plugin
 
 class TempsgraphPlugin(octoprint.plugin.SettingsPlugin,
-                       octoprint.plugin.AssetPlugin):
+                       octoprint.plugin.AssetPlugin,
+                       octoprint.plugin.TemplatePlugin):
 
     ##~~ SettingsPlugin mixin
 
     def get_settings_defaults(self):
         return dict(
-            # put your plugin's default settings here
+            enableCustomization=False,
+            backgroundPresets=[
+                dict(
+                    name="Default",
+                    value=None),
+                dict(
+                    name="Discorded",
+                    value="#36393f"),
+                dict(
+                    name="Custom",
+                    value="#fffff")],
+            legendPresets=[
+                dict(
+                    name="Default",
+                    value=None),
+                dict(
+                    name="Discorded",
+                    value="#dadadc"),
+                dict(
+                    name="Custom",
+                    value="#fffff")],
+            color=dict(
+                backgroundColor = 'Default',
+                legendColor="Default"
+            )
+            
         )
 
     ##~~ AssetPlugin mixin
@@ -45,7 +71,10 @@ class TempsgraphPlugin(octoprint.plugin.SettingsPlugin,
                 pip="https://github.com/1r0b1n0/OctoPrint-Tempsgraph/archive/{target_version}.zip"
             )
         )
-
+    def get_template_configs(self):
+        return [
+            dict(type="settings", custom_bindings=True)
+        ]
 
 __plugin_name__ = "Tempsgraph Plugin"
 

--- a/octoprint_tempsgraph/templates/tempsgraph_settings.jinja2
+++ b/octoprint_tempsgraph/templates/tempsgraph_settings.jinja2
@@ -1,0 +1,44 @@
+<form class="form-horizontal">
+    <h4>General</h4>
+    <fieldset>
+        <div class="control-group">
+            <label class="control-label"></label>
+            <div class="controls">
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: ownSettings.enableCustomization"> Enable customization
+                </label>
+            </div>
+
+        </div>
+        <div class="control-group">
+            <label class="control-label">Background color</label>
+            <div class="controls">
+                 <select data-bind="options: backgroundColors,
+                       optionsText: 'name',
+                       value: selectedBackground,
+                       optionsValue: 'name'"></select>
+            </div>
+         <div class="control-group" data-bind="visible: selectedBackground() == 'Custom'">
+            <label class="control-label">Custom color</label>
+            <div class="controls">
+                <input type="color" class="input-mini" data-bind="value: backgroundColor">
+                <input type="text" class="input-mini" data-bind="value: backgroundColor">
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">Legend (text) color</label>
+            <div class="controls">
+                    <select data-bind="options: legendColors,
+                        optionsText: 'name',
+                        value: selectedLegend,
+                        optionsValue: 'name'"></select>
+            </div>
+            <div class="control-group" data-bind="visible: selectedLegend() == 'Custom'">
+            <label class="control-label">Custom color</label>
+            <div class="controls">
+                <input type="color" class="input-mini" data-bind="value: legendColor">
+                <input type="text" class="input-mini" data-bind="value: legendColor">
+            </div>
+    </fieldset>
+
+</form>

--- a/octoprint_tempsgraph/templates/tempsgraph_settings.jinja2
+++ b/octoprint_tempsgraph/templates/tempsgraph_settings.jinja2
@@ -26,18 +26,18 @@
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">Legend (text) color</label>
+            <label class="control-label">Axises text color</label>
             <div class="controls">
-                    <select data-bind="options: legendColors,
+                    <select data-bind="options: axisesColors,
                         optionsText: 'name',
-                        value: selectedLegend,
+                        value: selectedAxises,
                         optionsValue: 'name'"></select>
             </div>
-            <div class="control-group" data-bind="visible: selectedLegend() == 'Custom'">
+            <div class="control-group" data-bind="visible: selectedAxises() == 'Custom'">
             <label class="control-label">Custom color</label>
             <div class="controls">
-                <input type="color" class="input-mini" data-bind="value: legendColor">
-                <input type="text" class="input-mini" data-bind="value: legendColor">
+                <input type="color" class="input-mini" data-bind="value: axisesColor">
+                <input type="text" class="input-mini" data-bind="value: axisesColor">
             </div>
     </fieldset>
 


### PR DESCRIPTION
I've implemented some customisation for background- and axises text-colour. 
There are three presets: choices, default, Discorded and custom. 

The changes does not need a refresh to be applied, everything is dynamic.

This fixes your #6 and my https://github.com/Birkbjo/OctoPrint-Themeify/issues/12

Screenshot of settings: 
![screen shot 2018-01-29 at 13 10 57](https://user-images.githubusercontent.com/13852438/35510043-c51419f0-04f6-11e8-9993-a1a32b43d505.png)
