### PR TITLE
Mark as python 3 compatible

### DIFF
--- a/extras/tempsgraph.md
+++ b/extras/tempsgraph.md
@@ -33,6 +33,7 @@ featuredimage: /assets/img/plugins/tempsgraph/zoom.png
 compatibility:
   octoprint:
   - 1.3.2
+  python: ">=2.7,<4"
 
 ---
 

--- a/octoprint_tempsgraph/__init__.py
+++ b/octoprint_tempsgraph/__init__.py
@@ -78,6 +78,8 @@ class TempsgraphPlugin(octoprint.plugin.SettingsPlugin,
 
 __plugin_name__ = "Tempsgraph Plugin"
 
+__plugin_pythoncompat__ = ">=2.7,<4"
+
 def __plugin_load__():
     global __plugin_implementation__
     __plugin_implementation__ = TempsgraphPlugin()


### PR DESCRIPTION
It works fine in my testing running on Python 3.8, but plugins have to be explicitly marked as compatible to allow the installation through the plugin manager.